### PR TITLE
New instruction format for gensimd and other cleanup

### DIFF
--- a/intrinsics.go
+++ b/intrinsics.go
@@ -378,3 +378,76 @@ func getTextR(z *html.Tokenizer) string {
 	}
 	return r
 }
+
+func fixType(s string, importname string) string {
+	pointer := false
+	if strings.Contains(s, "*") {
+		pointer = true
+	}
+	r := CamelCase(s)
+	if len(r) == 0 {
+		return ""
+	}
+	rb := []byte(r)
+	if rb[0] == 'm' {
+		rb[0] = 'M'
+		r = importname + "." + string(rb)
+	}
+
+	switch r {
+	case "void":
+		if pointer {
+			r = "uintptr"
+		} else {
+			r = ""
+		}
+	case "char", "charConst":
+		r = "byte"
+	case "unsignedChar":
+		r = "uint8"
+	case "unsignedShort":
+		r = "uint16"
+	case "sizeT", "constInt", "intConst":
+		r = "int"
+	case "int64Const":
+		r = "int"
+	case "unsignedInt64":
+		r = "uint64"
+	case "unsigned", "constUnsignedInt":
+		r = "uint"
+	case "unsignedInt", "unsignedLong":
+		r = "uint32"
+	case "unsignedInt32":
+		r = "uint32"
+	case "voidConst":
+		r = "uintptr"
+	case "constVoid":
+		r = "uintptr"
+	case "mem_addr":
+		r = "uintptr"
+	case "float", "constFloat":
+		r = "float32"
+	case "double", "constDouble":
+		r = "float64"
+	case "short":
+		r = "int16"
+	case "floatConst":
+		r = "uintptr"
+	case "doubleConst":
+		r = "uintptr"
+	case "longLong":
+		r = "int64"
+	case "constMMCMPINTENUM":
+		r = "uint8"
+	}
+
+	if r == "uintptr" || r == "" {
+		return r
+	}
+
+	if pointer {
+		r = "*" + r
+	}
+	return r
+
+}

--- a/intrinsics.go
+++ b/intrinsics.go
@@ -47,10 +47,9 @@ type Perf map[string]Timing
 //var m64, m128, m256, m512, gen *os.File
 //var m64a, m128a, m256a, m512a, gena *os.File
 type pack struct {
-	goFile    *os.File
-	toAsmFile *os.File
-	instrFile *os.File
-	asmFile   *os.File
+	goFile      *os.File
+	toInstrFile *os.File
+	asmFile     *os.File
 }
 
 var genimport = `import . "github.com/klauspost/intrinsics/x86"`
@@ -376,7 +375,6 @@ func getTextR(z *html.Tokenizer) string {
 			return r
 		}
 	}
-	return r
 }
 
 func fixType(s string, importname string) string {

--- a/parseintrin.go
+++ b/parseintrin.go
@@ -50,8 +50,6 @@ func parseHTMLX86(f io.Reader) error {
 			}
 		}
 	}
-	in.FinishX86()
-	return nil
 }
 
 func parseDivX86(z *html.Tokenizer, in *Intrinsic) *Intrinsic {
@@ -196,7 +194,6 @@ func parseTableX86(z *html.Tokenizer, in *Intrinsic) *Intrinsic {
 			}
 		}
 	}
-	return in
 }
 
 func fixTypeX86(s string) string {
@@ -338,7 +335,6 @@ func (in Intrinsic) FinishX86() {
 			fmt.Fprintf(out, " - uses instrunction: %s", in.Instruction)
 		}
 	}
-	fmt.Fprintln(out, "\n")
 
 	// Attempts to write a return value
 	if in.RetType != "" {

--- a/parseintrin.go
+++ b/parseintrin.go
@@ -200,76 +200,7 @@ func parseTableX86(z *html.Tokenizer, in *Intrinsic) *Intrinsic {
 }
 
 func fixTypeX86(s string) string {
-	pointer := false
-	if strings.Contains(s, "*") {
-		pointer = true
-	}
-	r := CamelCase(s)
-	if len(r) == 0 {
-		return ""
-	}
-	rb := []byte(r)
-	if rb[0] == 'm' {
-		rb[0] = 'M'
-		r = "x86." + string(rb)
-	}
-
-	switch r {
-	case "void":
-		if pointer {
-			r = "uintptr"
-		} else {
-			r = ""
-		}
-	case "char", "charConst":
-		r = "byte"
-	case "unsignedChar":
-		r = "uint8"
-	case "unsignedShort":
-		r = "uint16"
-	case "sizeT", "constInt", "intConst":
-		r = "int"
-	case "int64Const":
-		r = "int"
-	case "unsignedInt64":
-		r = "uint64"
-	case "unsigned", "constUnsignedInt":
-		r = "uint"
-	case "unsignedInt", "unsignedLong":
-		r = "uint32"
-	case "unsignedInt32":
-		r = "uint32"
-	case "voidConst":
-		r = "uintptr"
-	case "constVoid":
-		r = "uintptr"
-	case "mem_addr":
-		r = "uintptr"
-	case "float", "constFloat":
-		r = "float32"
-	case "double", "constDouble":
-		r = "float64"
-	case "short":
-		r = "int16"
-	case "floatConst":
-		r = "uintptr"
-	case "doubleConst":
-		r = "uintptr"
-	case "longLong":
-		r = "int64"
-	case "constMMCMPINTENUM":
-		r = "uint8"
-	}
-
-	if r == "uintptr" || r == "" {
-		return r
-	}
-
-	if pointer {
-		r = "*" + r
-	}
-	return r
-
+	return fixType(s, "x86")
 }
 
 func (in Intrinsic) hasImmediateX86() bool {

--- a/parseintrinsimd.go
+++ b/parseintrinsimd.go
@@ -24,11 +24,8 @@ func parsesimd() {
 	parseHTMLSimd(f)
 	for _, pk := range packages {
 		pk.goFile.Close()
-		pk.toAsmFile.WriteString("}\n")
-		pk.toAsmFile.Close()
-		pk.instrFile.WriteString(")\n")
-		pk.instrFile.Close()
-
+		pk.toInstrFile.WriteString("}\n")
+		pk.toInstrFile.Close()
 	}
 }
 
@@ -54,8 +51,6 @@ func parseHTMLSimd(f io.Reader) error {
 			}
 		}
 	}
-	in.FinishSimd()
-	return nil
 }
 
 func parseDivSimd(z *html.Tokenizer, in *Intrinsic) *Intrinsic {
@@ -111,7 +106,7 @@ func (i Intrinsic) getFilesSimd() pack {
 		if err != nil {
 			panic(err)
 		}
-		err = os.MkdirAll("codegen/"+pk, 0777)
+		err = os.MkdirAll("codegen/", 0777)
 		if err != nil {
 			panic(err)
 		}
@@ -127,51 +122,16 @@ func (i Intrinsic) getFilesSimd() pack {
 
 		p.goFile.WriteString(`var _ = simd.M128{}  // Make sure we use simd package` + "\n\n")
 
-		p.toAsmFile, err = os.Create("codegen/" + pk + ".go")
+		p.toInstrFile, err = os.Create("codegen/" + pk + ".go")
 		if err != nil {
 			panic(err)
 		}
-		p.toAsmFile.WriteString("package codegen\n\n")
-		p.toAsmFile.WriteString("import (\n")
-		p.toAsmFile.WriteString("\t\"github.com/bjwbell/gensimd/simd/" + pk + "\"\n")
-		p.toAsmFile.WriteString(")\n")
-		p.toAsmFile.WriteString("\n")
-		p.toAsmFile.WriteString("var " + pk + "ToGoAsm = map[" + pk + ".Instr]Instr{\n")
-
-		p.instrFile, err = os.Create("codegen/" + pk + "/instructions.go")
-		if err != nil {
-			panic(err)
-		}
-		p.instrFile.WriteString("package " + pk + "\n\n")
-		if err != nil {
-			panic(err)
-		}
-		p.instrFile.WriteString("type Instr int\n")
-		p.instrFile.WriteString(`
-// SSE2 types
-type M128i [16]byte
-type M128 [4]float32
-type M128d [2]float64
-
-// AVX
-type M256 [8]float32
-type M256i [32]byte
-type M256d [4]float64
-
-// AVX2
-type M512 [16]float32
-type M512i [64]byte
-type M512d [8]float64
-
-type Mmask8 uint8
-type Mmask16 uint16
-type Mmask32 uint32
-type Mmask64 uint64
-
-const (
-	INVALID Instr = iota
-`)
-
+		p.toInstrFile.WriteString("package codegen\n\n")
+		p.toInstrFile.WriteString("import (\n")
+		p.toInstrFile.WriteString("\t\"github.com/bjwbell/gensimd/simd/" + pk + "\"\n")
+		p.toInstrFile.WriteString(")\n")
+		p.toInstrFile.WriteString("\n")
+		p.toInstrFile.WriteString(getInstrTable(pk))
 		packages[pk] = p
 	}
 	return p
@@ -245,7 +205,6 @@ func parseTableSimd(z *html.Tokenizer, in *Intrinsic) *Intrinsic {
 			}
 		}
 	}
-	return in
 }
 
 func fixTypeSimd(s string) string {
@@ -306,21 +265,37 @@ func (in Intrinsic) FinishSimd() {
 	fmt.Fprintln(out, "}")
 	fmt.Fprintln(out, "")
 
-	out = in.getFilesSimd().toAsmFile
+	out = in.getFilesSimd().toInstrFile
 	if in.Instruction == "..." || in.Instruction == "" {
 		fmt.Fprintln(out, "\t// Add Composite: "+in.Package+"."+in.Name)
 	} else {
-		fmt.Fprintln(out, "\t"+in.Package+"."+in.Name+":"+in.Instruction+",")
+		fmt.Fprintln(out, in.makeGenSimd())
 	}
+}
 
-	if in.Instruction != "..." && in.Instruction != "" {
-		_, ok := wroteAsm[in.Package+in.Instruction]
-		if !ok {
-			out = in.getFilesSimd().instrFile
-			fmt.Fprintln(out, "\t"+in.Instruction)
+func (in Intrinsic) makeGenSimd() string {
+	name := in.Name
+	instructionName := in.Instruction
+	resultIdxOp := 1
+	varOps := ""
+	for _, p := range in.Params {
+		// for now skip instructions that use non simd.* params
+		if p.Type != "simd.M128" && p.Type != "simd.M128i" && p.Type != "simd.M128d" {
+			return ""
 		}
-		wroteAsm[in.Package+in.Instruction] = struct{}{}
+		v := fmt.Sprintf("Var: Variable{reflect.TypeOf(%v{})}", p.Type)
+		op := fmt.Sprintf("Op:  Operand{Flags: In | Out, Reg: XMM_REG, NamedReg: REG_INVALID}")
+		varOp := fmt.Sprintf("\t\t\t{%v, %v,},\n", v, op)
+		varOps += varOp
 	}
+	varOps = fmt.Sprintf("[]VarOp{\n%v\t\t},\n", varOps)
+
+	instruction := fmt.Sprintf("\t{\n\t\tName:            \"%v\",\n\t\tInstructionName: \"%v\",\n\t\tVarOps: %v\t\tResultIdxOp: %v,\n\t},", name, instructionName, varOps, resultIdxOp)
+	return instruction
+}
+
+func getInstrTable(pkg string) string {
+	return fmt.Sprintf("var %vIntrTable = []Intrinsic{\n", pkg)
 }
 
 func (p Params) getAsmSimd() (string, int) {

--- a/parseintrinsimd.go
+++ b/parseintrinsimd.go
@@ -249,76 +249,7 @@ func parseTableSimd(z *html.Tokenizer, in *Intrinsic) *Intrinsic {
 }
 
 func fixTypeSimd(s string) string {
-	pointer := false
-	if strings.Contains(s, "*") {
-		pointer = true
-	}
-	r := CamelCase(s)
-	if len(r) == 0 {
-		return ""
-	}
-	rb := []byte(r)
-	if rb[0] == 'm' {
-		rb[0] = 'M'
-		r = "simd." + string(rb)
-	}
-
-	switch r {
-	case "void":
-		if pointer {
-			r = "uintptr"
-		} else {
-			r = ""
-		}
-	case "char", "charConst":
-		r = "byte"
-	case "unsignedChar":
-		r = "uint8"
-	case "unsignedShort":
-		r = "uint16"
-	case "sizeT", "constInt", "intConst":
-		r = "int"
-	case "int64Const":
-		r = "int"
-	case "unsignedInt64":
-		r = "uint64"
-	case "unsigned", "constUnsignedInt":
-		r = "uint"
-	case "unsignedInt", "unsignedLong":
-		r = "uint32"
-	case "unsignedInt32":
-		r = "uint32"
-	case "voidConst":
-		r = "uintptr"
-	case "constVoid":
-		r = "uintptr"
-	case "mem_addr":
-		r = "uintptr"
-	case "float", "constFloat":
-		r = "float32"
-	case "double", "constDouble":
-		r = "float64"
-	case "short":
-		r = "int16"
-	case "floatConst":
-		r = "uintptr"
-	case "doubleConst":
-		r = "uintptr"
-	case "longLong":
-		r = "int64"
-	case "constMMCMPINTENUM":
-		r = "uint8"
-	}
-
-	if r == "uintptr" || r == "" {
-		return r
-	}
-
-	if pointer {
-		r = "*" + r
-	}
-	return r
-
+	return fixType(s, "simd")
 }
 
 var wroteAsm = make(map[string]struct{})

--- a/x86/convert.go
+++ b/x86/convert.go
@@ -1,56 +1,97 @@
 package x86
 
+import (
+    "reflect"
+    "unsafe"
+)
+
 // FloatToM128 converts a slice into M128 array.
 // The number of elements is len(src) / 4.
-// FIXME: Should simply be a pointer to the original data, not a copy
 func FloatToM128(src []float32) []M128 {
-	l := len(src) / 4
-	dst := make([]M128, l)
-	for i := 0; i < l; i++ {
-		dst[i] = M128{src[i*4], src[i*4+1], src[i*4+2], src[i*4+3]}
-	}
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&src))
+
+	// The length and capacity of the slice are different.
+	header.Len /= 4
+	header.Cap /= 4
+
+	// Convert slice header to an []int32
+	dst := *(*[]M128)(unsafe.Pointer(&header))
+
+	return dst
+}
+
+// M128ToFloat converts M128 slice to a float32 slice.
+// The number of elements is len(src) * 4.
+func M128ToFloat(src []M128) []float32 {
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&src))
+
+	// The length and capacity of the slice are different.
+	header.Len *= 4
+	header.Cap *= 4
+
+	// Convert slice header to an []int32
+	dst := *(*[]float32)(unsafe.Pointer(&header))
+
 	return dst
 }
 
 // BytesToM128i converts a byte slice into M128i array.
 // The number of elements is len(src) / 16.
-// FIXME: Should simply be a pointer to the original data, not a copy
 func BytesToM128i(src []byte) []M128i {
-	l := len(src) / 16
-	dst := make([]M128i, l)
-	for i := 0; i < l; i++ {
-		d := M128i{}
-		for j, n := range src[:16] {
-			d[j] = n
-		}
-		dst[i] = d
-		src = src[16:]
-	}
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&src))
+
+	// The length and capacity of the slice are different.
+	header.Len /= 16
+	header.Cap /= 16
+
+	// Convert slice header to an []int32
+	dst := *(*[]M128i)(unsafe.Pointer(&header))
+
 	return dst
 }
 
 // M128iToBytes converts M128i slice to a byte slice.
 // The number of elements is len(src) * 16.
-// FIXME: Should simply be a pointer to the original data, not a copy
 func M128iToBytes(src []M128i) []byte {
-	l := len(src) * 16
-	dst := make([]byte, l)
-	for i := 0; i < l; i++ {
-		for j, n := range src[i] {
-			dst[i*16+j] = n
-		}
-	}
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&src))
+
+	// The length and capacity of the slice are different.
+	header.Len *= 16
+	header.Cap *= 16
+
+	// Convert slice header to an []int32
+	dst := *(*[]byte)(unsafe.Pointer(&header))
+
 	return dst
 }
 
+
 // DoubleToM128d converts a slice into M128d array.
 // The number of elements is len(src) / 2.
-// FIXME: Should simply be a pointer to the original data, not a copy
 func DoubleToM128d(src []float64) []M128d {
-	l := len(src) / 2
-	dst := make([]M128d, l)
-	for i := 0; i < l; i++ {
-		dst[i] = M128d{src[i*2], src[i*2+1]}
-	}
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&src))
+
+	// The length and capacity of the slice are different.
+	header.Len /= 2
+	header.Cap /= 2
+
+	// Convert slice header to an []int32
+	dst := *(*[]M128d)(unsafe.Pointer(&header))
+
+	return dst
+}
+
+// M128ToFloat converts M128 slice to a float64 slice.
+// The number of elements is len(src) * 2.
+func M128dToDouble(src []M128) []float64 {
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&src))
+
+	// The length and capacity of the slice are different.
+	header.Len *= 2
+	header.Cap *= 2
+
+	// Convert slice header to an []int32
+	dst := *(*[]float64)(unsafe.Pointer(&header))
+
 	return dst
 }

--- a/x86/intdiv.go
+++ b/x86/intdiv.go
@@ -1,5 +1,11 @@
+//+build ignore
+
 package x86
 
+import(
+	"github.com/klauspost/intrinsics/x86/sse2"
+	"github.com/klauspost/intrinsics/x86/misc"
+)
 // The instruction set does not support integer vector division. Instead, we
 // are using a method for fast integer division based on multiplication and
 // shift operations. This method is faster than simple integer division if the

--- a/x86/m128_test.go
+++ b/x86/m128_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestAddEpi8(t *testing.T) {
-	a := sse2.SetEpi32(0x00010203, 0x04050607, 0x08090a0b, 0x0c0d0e0f)
-	b := sse2.SetEpi32(0x00010203, 0x04050607, 0x08090a0b, 0x0c0d0e0f)
+	a := sse2.SetEpi32(0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c)
+	b := sse2.SetEpi32(0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c)
 
 	c := sse2.AddEpi8(a, b)
 

--- a/x86/sse/sse_amd64.s
+++ b/x86/sse/sse_amd64.s
@@ -40,7 +40,7 @@ TEXT ·addPs(SB),7,$0
 	MOVOU b+16(FP),X1
 
 	// TODO: Code missing - could be:
-	// ADDPS X0, X1
+	ADDPS X0, X1
 
 	MOVOU X1, ret+32(FP)
 	RET
@@ -1507,7 +1507,7 @@ TEXT ·mulPs(SB),7,$0
 	MOVOU b+16(FP),X1
 
 	// TODO: Code missing - could be:
-	// MULPS X0, X1
+	MULPS X0, X1
 
 	MOVOU X1, ret+32(FP)
 	RET
@@ -1853,13 +1853,7 @@ TEXT ·mMSETFLUSHZEROMODE(SB),7,$0
 
 // func setPs(e3 float32, e2 float32, e1 float32, e0 float32) [4]float32
 TEXT ·setPs(SB),7,$0
-	MOVL e3+0(FP),R8
-	MOVL e2+4(FP),R9
-	MOVL e1+8(FP),R10
-	MOVL e0+12(FP),R11
-
-	// TODO: Code missing
-
+	MOVOU e3+0(FP), X3
 	MOVOU X3, ret+16(FP)
 	RET
 

--- a/x86/sse2/sse2_amd64.s
+++ b/x86/sse2/sse2_amd64.s
@@ -37,7 +37,7 @@ TEXT ·addEpi8(SB),7,$0
 	MOVOU b+16(FP),X1
 
 	// TODO: Code missing - could be:
-	// PADDB X0, X1
+	PADDB X0, X1
 
 	MOVOU X1, ret+32(FP)
 	RET
@@ -1378,7 +1378,11 @@ TEXT ·setEpi32(SB),7,$0
 
 	// TODO: Code missing
 
-	MOVOU X3, ret+32(FP)
+
+	MOVL R8, ret+32(FP)
+	MOVL R9, ret+36(FP)
+	MOVL R10, ret+40(FP)
+	MOVL R11, ret+44(FP)
 	RET
 
 // func setEpi64(e1 x86.M64, e0 x86.M64) [16]byte


### PR DESCRIPTION
Output new gensimd instruction table format when using the -simd flag. 

Other changes:
- Merge branch 'master' of github.com/klauspost/intrinsics into gensimd
- Combine fixType() functions in parseintrinsimd.go/parseintrin.go
- Remove dead code in intrinsics.go, parsearm.go, parseintrin.go, and
  parseintrinsimd.go
